### PR TITLE
Users can only delete their own comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
@@ -2,9 +2,14 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 import java.io.IOException;
+import java.io.PrintWriter;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -15,11 +20,32 @@ import javax.servlet.http.HttpServletResponse;
 public class DeleteCommentServlet extends HttpServlet {
 
   @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    long id = Long.parseLong(request.getParameter("id"));
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    try {
+      long id = Long.parseLong(request.getParameter("id"));
+      Key commentEntityKey = KeyFactory.createKey("Comment", id);
+      DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-    Key commentEntityKey = KeyFactory.createKey("Comment", id);
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    datastore.delete(commentEntityKey);
+      // get email of the user who wrote the comment
+      Entity commentEntity = datastore.get(commentEntityKey);
+      String authorEmail = (String) commentEntity.getProperty("email");
+
+      // get email of current user who is trying to delete comment
+      UserService userService = UserServiceFactory.getUserService();
+      String currentEmail = userService.getCurrentUser().getEmail();
+
+      response.setContentType("text/html");
+      PrintWriter out = response.getWriter();
+
+      if (currentEmail.equals(authorEmail)) {
+        datastore.delete(commentEntityKey);
+        out.append("Allowed");
+      } else {
+        out.append("Not allowed");
+      }
+      out.close();
+    } catch (EntityNotFoundException e) {
+      System.out.println("Can't fetch entity");
+    }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
@@ -9,7 +9,6 @@ import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import java.io.IOException;
-import java.io.PrintWriter;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -34,16 +33,11 @@ public class DeleteCommentServlet extends HttpServlet {
       UserService userService = UserServiceFactory.getUserService();
       String currentEmail = userService.getCurrentUser().getEmail();
 
-      response.setContentType("text/html");
-      PrintWriter out = response.getWriter();
-
       if (currentEmail.equals(authorEmail)) {
         datastore.delete(commentEntityKey);
-        out.append("Allowed");
       } else {
-        out.append("Not allowed");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
       }
-      out.close();
     } catch (EntityNotFoundException e) {
       System.out.println("Can't fetch entity");
     }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -109,8 +109,7 @@ function createCommentElement(comment) {
     checks whether the person who want to delete the comment is
     the same as the person who wrote the comment */
     fetch('/delete-comment?id=' + comment.id).then((response) => {
-      const statusCodeForbidden = 403;
-      if (response.status != statusCodeForbidden) {
+      if (response.ok) {
         commentElement.remove();
       }
     });

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -42,7 +42,6 @@ function addRandomFact() {
 function checkLogin() {
   fetch('/login-status').then((response) =>
     response.json()).then((json) => {
-    console.log(json);
     const url = createAnchorElement(json);
 
     const content = document.getElementById('content');
@@ -106,9 +105,15 @@ function createCommentElement(comment) {
   const deleteBttn = document.createElement('button');
   deleteBttn.innerText = 'Delete';
   deleteBttn.addEventListener('click', () => {
-    deleteComment(comment);
-
-    commentElement.remove();
+    /* when delete button is pressed, send comment to servlet which
+    checks whether the person who want to delete the comment is
+    the same as the person who wrote the comment */
+    fetch('/delete-comment?id=' + comment.id).then((response) =>
+      response.text()).then((text) => {
+      if (text == 'Allowed') {
+        commentElement.remove();
+      }
+    });
   });
 
   const scoreBttn = document.createElement('button');
@@ -138,13 +143,3 @@ function createCommentElement(comment) {
   return commentElement;
 }
 
-/**
- * Delete comment through servlet
- * @param {Promise} comment
- * @return {void}
- */
-function deleteComment(comment) {
-  const params = new URLSearchParams();
-  params.append('id', comment.id);
-  fetch('/delete-comment', {method: 'POST', body: params});
-}

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -108,9 +108,9 @@ function createCommentElement(comment) {
     /* when delete button is pressed, send comment to servlet which
     checks whether the person who want to delete the comment is
     the same as the person who wrote the comment */
-    fetch('/delete-comment?id=' + comment.id).then((response) =>
-      response.text()).then((text) => {
-      if (text == 'Allowed') {
+    fetch('/delete-comment?id=' + comment.id).then((response) => {
+      const statusCodeForbidden = 403;
+      if (response.status != statusCodeForbidden) {
         commentElement.remove();
       }
     });


### PR DESCRIPTION
### DeleteCommentServlet.java
* Servlet can receive requests that contain a comment id.
* Based on the id, it will 
  - get the corresponding comment entity from persistent storage
  - get email of the author of the comment
  - get email of the current user
  - if the two emails are the same:
    - delete comment from persistent storage
    - send text confirmation to JS that the deletion was allowed

### script.js
* When delete button is pressed trigger the behaviour of DeleteCommentServlet
* If response confirms that deletion was successful, remove comment box in the frontend
* I removed `deleteComment()` method which was no longer needed

### [Deployed code](https://ioanalazar-step-2020.appspot.com/)